### PR TITLE
Providing individual response headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,7 +93,6 @@ function Interfake(o) {
 
 			res.setHeader('Content-Type', 'application/json');
 			
-            console.log(data.response.headers);
             if (data.response.headers) {
               for (i in data.response.headers) {
                 res.setHeader(i, data.response.headers[i]);

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -43,6 +43,7 @@ describe('Interfake HTTP API', function () {
 				})
 				.then(function (results) {
                     assert.equal(results[0].headers['foo'], 'bar');
+                    // console.log(results[0].cookies)
 					assert.equal(results[0].statusCode, 200);
 					assert.equal(results[1].hi, 'there');
 					interfake.stop();


### PR DESCRIPTION
You can now provide individual response headers via .headers in the response config 
