### PR TITLE
Add support for handling query params

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ function Interfake(o) {
 	var app = express();
 	var server;
 	var fluentInterface = new FluentInterface(this, o);
+    var expectationsLookup = {};
 
 	app.configure(function(){
 		app.use(express.json());
@@ -78,6 +79,28 @@ function Interfake(o) {
 		return result;
 	}
 
+    function createRouteHash(requestDescriptor) {
+        var finalRoute;
+        var initialRoute = requestDescriptor.method.toUpperCase() + ' ' + requestDescriptor.url;
+        if (requestDescriptor.query) {
+            var queryKeys = Object.keys(requestDescriptor.query).filter(function (key) {
+                return key !== 'callback';
+            });
+            if (queryKeys.length) {
+                finalRoute = initialRoute + '?' + queryKeys.sort().map(function (key) {
+                    return encodeURIComponent(key) + '=' + encodeURIComponent(requestDescriptor.query[key]);
+                }).join(';');
+            }
+        }
+
+        if (!finalRoute) {
+            finalRoute = initialRoute;
+        }
+
+        debug('Lookup hash key will be: ' + finalRoute);
+        return finalRoute;
+    }
+
 	function createRoute(data) {
 		var specifiedRequest, specifiedResponse, afterSpecifiedResponse;
 		if (!data.request || !data.request.method || !data.request.url || !data.response || !data.response.code) {
@@ -97,9 +120,26 @@ function Interfake(o) {
 
 		clearRouteForRequest(specifiedRequest);
 
+        // Register query params/response in lookup hash
+        expectationsLookup[createRouteHash(specifiedRequest)] = {
+            response: data.response,
+            afterResponse: data.afterResponse
+        };
+
 		app[specifiedRequest.method](specifiedRequest.url, function (req, res) {
-			var specifiedResponse = req.route.responseData;
-			var afterSpecifiedResponse = req.route.afterResponseData;
+            var expectData = expectationsLookup[createRouteHash({
+                method: req.method,
+                url: req.path,
+                query: req.query
+            })];
+
+            if (!expectData) {
+                debug('Found matching path route, but no matching data for given query params');
+                return res.send(404);
+            }
+
+			var specifiedResponse = expectData.response; // req.route.responseData;
+			var afterSpecifiedResponse = expectData.afterResponse; //req.route.afterResponseData;
 			var responseDelay = determineDelay(specifiedResponse.delay);
 
 			debug(req.method, 'request to', req.url, 'returning', specifiedResponse.code);


### PR DESCRIPTION
We wanted to use interfake to be able to handle requests like:

```
GET /something?query=12
```

But of course it was failing to register this correctly.  This pull request adds support for query parameters by allowing you to call createRoute as follows:

``` js
interfake.createRoute({
    request: {
        url: '/something',
        query: {
            query: 12
        },
        method: 'get'
    },
    response: {
        status: 200,
        body: { response: 'body' }
    }
});
```

Commit message:
Added createRouteHash() to maintain canonical form of a request.
Use lookup table to store expected responses, with route-hash as key.
Add tests to confirm query params work.
All tests pass, with modifications.
Added afterEach() to ensure interfake.stop() is called after each test, even if the test fails.
