### PR TITLE
Add a callback argument to Interfake.listen

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -217,10 +217,13 @@ function Interfake(o) {
 		app.use(path, express.static(directory));
 	};
 
-	this.listen = function (port) {
+	this.listen = function (port, callback) {
 		port = port || 3000;
 		server = app.listen(port, function () {
 			debug('Interfake is listening for requests on port ' + port);
+			if(util.isFunction(callback)) {
+				callback();
+			}
 		});
 	};
 

--- a/tests/javascript.test.js
+++ b/tests/javascript.test.js
@@ -25,6 +25,11 @@ describe('Interfake JavaScript API', function () {
 			interfake.stop();
 		}
 	});
+	describe('#listen', function() {
+		it('should should support a callback', function(done){
+			interfake.listen(3000, done);
+		});
+	});
 	describe('#createRoute()', function () {
 		it('should create one GET endpoint', function (done) {
 			interfake.createRoute({


### PR DESCRIPTION
server.listen is asynchronous, which means that Interfake.listen is asynchronous too.

Hence, I thought it might be worth adding a callback to Interfake.listen to allow users to know that the api is up before continuing.
