### PR TITLE
fix copying of proxied query strings

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -134,11 +134,11 @@ function Interfake(o) {
 		if (specifiedResponse.proxy) {
 			proxyQueryStrings = {};
 			if (req.query) {
-				for (var key in req.query) {
+				Object.keys(req.query).forEach(function(key) {
 					if (key !== 'callback') {
 						proxyQueryStrings[key] = req.query[key];
 					}
-				}
+				});
 			}
 			debug('Proxy query strings are', proxyQueryStrings);
 			request[req.method.toLowerCase()]({ url : specifiedResponse.proxy.url || specifiedResponse.proxy, json : true, body : req.body, qs: proxyQueryStrings, headers : specifiedResponse.proxy.headers || {} }, function (error, response, body) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -134,11 +134,11 @@ function Interfake(o) {
 		if (specifiedResponse.proxy) {
 			proxyQueryStrings = {};
 			if (req.query) {
-				Object.keys(req.query).forEach(function (key, value) {
+				for (var key in req.query) {
 					if (key !== 'callback') {
-						proxyQueryStrings[key] = value;
+						proxyQueryStrings[key] = req.query[key];
 					}
-				});
+				}
 			}
 			debug('Proxy query strings are', proxyQueryStrings);
 			request[req.method.toLowerCase()]({ url : specifiedResponse.proxy.url || specifiedResponse.proxy, json : true, body : req.body, qs: proxyQueryStrings, headers : specifiedResponse.proxy.headers || {} }, function (error, response, body) {


### PR DESCRIPTION
It's not possible to access `value` while iterating over `Object.keys`, so all proxied query strings have value of `0`. This fix correctly copies the query parameter values.