### PR TITLE
[in progress] simple regexp support for json specified endpoints

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -30,6 +30,15 @@ function Route(descriptor, o) {
 
 	this.response.query = {};
 
+	// Might already be a RegExp
+	if (util.isString(this.request.url)) {
+		var jsonRegExp = this.request.url.match(/^regexp=(.*)/);
+		if (jsonRegExp) {
+			this.request.url = new RegExp(jsonRegExp[1]);
+			this.debug('Found RegExp in JSON endpoint', jsonRegExp)
+		};
+	};
+
 	// Alternatively, it's a RegExp. If so, leave it alone!
 	if (util.isString(this.request.url)) {
 		path = url.parse(this.request.url, true);


### PR DESCRIPTION
Hey, this one is more of a feature discussion than a real PR at the moment.
So I realized I needed regexp endpoints and I was using the JSON method, and couldn't find any support for regexps this way (only the JS method?), so I did this really rough solution to be able to do that. And my JSON would look like this

```js
[
  {
    "request": {
      "url": "regexp=\/some\/v0\/endpoint/(.*)",
      "method": "get"
    },
    "response": {
      "code": 200,
      "body": {}
    }
  }
]
```

This is probably in the completely wrong place. Also it should probably be in the form a property e.g. `regexp: true` than a prefix. 
Thoughts?