### PR TITLE
Adding of get request array params support 

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -240,6 +240,10 @@ Route.prototype.compare = function (route) {
 			this.debug('4b. Testing', routeQueryValue, 'matches', this.request.query[key]);
 			same = same && this.request.query[key].test(routeQueryValue);
 			this.debug('4c. Result is', same);
+		} else if (util.isArray(this.request.query[key])) {
+			this.debug('4b. Testing', routeQueryValue, 'matches', this.request.query[key]);
+			same = same && JSON.stringify(this.request.query[key].sort()) ===  JSON.stringify(routeQueryValue.sort());
+			this.debug('4c. Result is', same);
 		} else {
 			// Not checking type because 1 and '1' are the same in this case
 			this.debug('4b. Comparing', this.request.query[key], 'and', routeQueryValue);

--- a/tests/fluent.test.js
+++ b/tests/fluent.test.js
@@ -188,6 +188,18 @@ describe('Interfake Fluent JavaScript API', function () {
 					});
 			});
 
+			it('should use an array to find array query string params, regardless of order', function (done) {
+				interfake.get('/fluent').query({ pages: [ "1", "2" ]}).status(200);
+				interfake.listen(3000);
+
+				Q.all([get({url:'http://localhost:3000/fluent?pages=1&pages=2',json:true}), get({url:'http://localhost:3000/fluent?pages=2&pages=1',json:true})])
+					.then(function (results) {
+						assert.equal(results[0][0].statusCode, 200);
+						assert.equal(results[1][0].statusCode, 200);
+						done();
+					});
+			});
+
 			describe('#status()', function () {
 				it('should create a GET endpoint which accepts different querystrings using both methods of querystring specification', function (done) {
 					interfake.get('/fluent?query=1').query({ page: 1 }).status(400);

--- a/tests/javascript.test.js
+++ b/tests/javascript.test.js
@@ -331,6 +331,32 @@ describe('Interfake JavaScript API', function() {
 			});
 		});
 
+		it('should create a GET endpoint that accepts a query array parameter', function(done) {
+			interfake.createRoute({
+				request: {
+					url: '/wantsQueryArrayParameter',
+					query: {
+						pages: ['1', '2']
+					},
+					method: 'get'
+				},
+				response: {
+        			code: 200,
+					body: {
+						high: 'hoe'
+					}
+				}
+			});
+			interfake.listen(3000);
+
+			request('http://localhost:3000/wantsQueryArrayParameter?pages=1&pages=2', function(error, response, body) {
+				assert.equal(error, undefined);
+				assert.equal(response.statusCode, 200);
+				assert.equal(body.high, 'hoe');
+				done();
+			});
+		});
+
 		it('should create one GET endpoint accepting query parameters with different responses', function() {
 			interfake.createRoute({
 				request: {


### PR DESCRIPTION
was trying to have array params in the query 
```
"query" : {
  "pages": ["page", "page2"]
}
```
thus, submitting this PR to have this functionality.
let me know if it is ok
